### PR TITLE
Add the possibility to use an existing mjmlEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,21 @@ gulp.task('default', function () {
 
 ```
 
+> If you have custom components linked to your own mjmlEngine, you can pass it to the gulp task so it uses your engine to render the html:
+
+``` javascript
+
+var gulp = require('gulp');
+var mjml = require('gulp-mjml')
+
+// Require your own components if needed, and your mjmlEngine
+// require('./components')
+var mjmlEngine = require('mjml')
+
+gulp.task('default', function () {
+  gulp.src('./test.mjml')
+    .pipe(mjml(mjmlEngine))
+    .pipe(gulp.dest('./html'))
+});
+
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1,26 +1,29 @@
 
 var through = require ('through2')
-  , mjmlEngine = require ('mjml').default
+  , mjmlDefaultEngine = require ('mjml').default
   , gutil = require ('gulp-util');
 
 var GulpError = gutil.PluginError,
-			NAME = 'MJML' 
+			NAME = 'MJML';
 
-module.exports = function mjml () {
+module.exports = function mjml (mjmlEngine) {
+  if(mjmlEngine === undefined) {
+    mjmlEngine = mjmlDefaultEngine;
+  }
+
 	return through.obj(function (file, enc, callback) {
-		
+
 		if (file.isStream()) {
-			this.emit('error', new PluginError(NAME, 'Streams are not supported!'))
+			this.emit('error', new PluginError(NAME, 'Streams are not supported!'));
 			return callback()
 		}
 
-	
 		if (file.isBuffer()) {
 			var output = file.clone();
 			output.contents = new Buffer(mjmlEngine.mjml2html(file.contents.toString()));
 			output.path = gutil.replaceExtension(file.path.toString(), '.html');
 			this.push(output);
 		}
-		return callback();	
+		return callback();
 	})
-}
+};


### PR DESCRIPTION
When you use custom mjml components, they are stored in mjmlEngine.elements. Therefore the gulp task needs to be able to take another mjmlEngine instance to be able to render these custom components (when you do `require('mjml')` from the gulp task, it is another instance).

If you are happy with the changes and do the merge, don't forget to update the version and eventually add me as a contributor :)

Many thanks.