### PR TITLE
strict mjml version

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "gulp": "^3.9.0",
     "gulp-util": "^3.0.7",
-    "mjml": "^3.0.0",
+    "mjml": "3.1.1",
     "through2": "^2.0.0"
   }
 }


### PR DESCRIPTION
Mjml 3.2 have problems with paths. Only files in current folder are working, this is working:

mjml order.blade.mjml -o order.blade.php

This is not working

mjml resources/order.blade.mjml -o resources/order.blade.php

order.blade.php is outputed in current folder, not in resources folder. Because of that generating from gulpfile.js is also not working...