### PR TITLE
Allow mjmlEngine to be null

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ var GulpError = gutil.PluginError
 var NAME = 'MJML'
 
 module.exports = function mjml (mjmlEngine, options) {
-  if(mjmlEngine === undefined) {
+  if(!mjmlEngine) {
     mjmlEngine = mjmlDefaultEngine
   }
   if (options === undefined) {


### PR DESCRIPTION
It looks better when we want to pass options but no mjmlEngine
``` javascript
mjml(null, {}) // 😃
mjml(undefined, {}) // 😕
```